### PR TITLE
PhoneNumberInput: allow only numeric, whitespace and some basic punctation characters in the input

### DIFF
--- a/src/PhoneNumberInput/PhoneNumberInput.php
+++ b/src/PhoneNumberInput/PhoneNumberInput.php
@@ -19,6 +19,8 @@ class PhoneNumberInput extends TextInput
     public const VALID_STRICT = Validator::class . '::validatePhoneNumberStrict';
     public const REGION = Validator::class . '::validatePhoneNumberRegion';
 
+    private const PHONE_NUMBER_REGEX = '[\s\d()\[\]~/.+-]+';
+
     /** @var string|null */
     private $defaultRegionCode;
 
@@ -33,7 +35,9 @@ class PhoneNumberInput extends TextInput
         $this->setHtmlType('tel');
         $this->setNullable();
         $this->setRequired(false); // BC with Nette 2.4
-        $this->addRule(self::VALID, NetteFormsValidator::$messages[self::VALID] ?? 'Please enter a valid phone number.');
+        $invalidValueErrorMessage = NetteFormsValidator::$messages[self::VALID] ?? 'Please enter a valid phone number.';
+        $this->addRule(Form::PATTERN, $invalidValueErrorMessage, self::PHONE_NUMBER_REGEX);
+        $this->addRule(self::VALID, $invalidValueErrorMessage);
     }
 
     public function getDefaultRegionCode(): ?string
@@ -99,7 +103,7 @@ class PhoneNumberInput extends TextInput
         $value = $this->getHttpData(Form::DATA_LINE);
 
         if ($value === '' || $value === Strings::trim($this->translate($this->emptyValue))) {
-            $this->value = null;
+            $this->value = '';
             $this->rawValue = $value;
             return;
         }
@@ -108,7 +112,7 @@ class PhoneNumberInput extends TextInput
             $this->setValue($value);
             $this->rawValue = $value;
         } catch (PhoneNumberParseException $exception) {
-            $this->value = null;
+            $this->value = '';
             $this->rawValue = $value;
         }
     }

--- a/tests/PhoneNumberInput/PhoneNumberInputTest.phpt
+++ b/tests/PhoneNumberInput/PhoneNumberInputTest.phpt
@@ -20,6 +20,12 @@ require_once __DIR__ . '/../bootstrap.php';
 class PhoneNumberInputTest extends TestCase
 {
 
+    private const PATTERN = '[\s\d()\[\]~/.+-]+';
+    private const RULE_PATTERN = '{"op":":pattern","msg":"Please enter a valid phone number.","arg":"[\\\\s\\\\d()\\\\[\\\\]~/.+-]+"}';
+    private const RULE_VALID = '{"op":"Nepada\\\\PhoneNumberInput\\\\Validator::validatePhoneNumber","msg":"Please enter a valid phone number."}';
+    private const RULE_OPTIONAL = '{"op":"optional"},';
+    private const RULE_REQUIRED = '{"op":":filled","msg":"true"},';
+
     /** @var bool */
     private $isNette24 = false;
 
@@ -50,19 +56,17 @@ class PhoneNumberInputTest extends TestCase
 
         $phoneInput->setValue('+420212345678');
         Assert::same(
-            '<input type="tel" name="phone" id="frm-phone" data-nette-rules=\'['
-            . ($this->isNette24 ? '{"op":"optional"},' : '')
-            . '{"op":"Nepada\\\\PhoneNumberInput\\\\Validator::validatePhoneNumber","msg":"Please enter a valid phone number."}'
-            . ']\' value="212 345 678" data-default-region-code="CZ">',
+            '<input type="tel" name="phone" pattern="' . self::PATTERN . '" id="frm-phone" '
+            . 'data-nette-rules=\'[' . ($this->isNette24 ? self::RULE_OPTIONAL : '') . self::RULE_PATTERN . ',' . self::RULE_VALID . ']\' '
+            . 'value="212 345 678" data-default-region-code="CZ">',
             (string) $phoneInput->getControl()
         );
 
         $phoneInput->setValue('+12015550123');
         Assert::same(
-            '<input type="tel" name="phone" id="frm-phone" data-nette-rules=\'['
-            . ($this->isNette24 ? '{"op":"optional"},' : '')
-            . '{"op":"Nepada\\\\PhoneNumberInput\\\\Validator::validatePhoneNumber","msg":"Please enter a valid phone number."}'
-            . ']\' value="+1 201-555-0123" data-default-region-code="CZ">',
+            '<input type="tel" name="phone" pattern="' . self::PATTERN . '" id="frm-phone" '
+            . 'data-nette-rules=\'[' . ($this->isNette24 ? self::RULE_OPTIONAL : '') . self::RULE_PATTERN . ',' . self::RULE_VALID . ']\' '
+            . 'value="+1 201-555-0123" data-default-region-code="CZ">',
             (string) $phoneInput->getControl()
         );
     }
@@ -76,19 +80,17 @@ class PhoneNumberInputTest extends TestCase
 
         $phoneInput->setValue('+420212345678');
         Assert::same(
-            '<input type="tel" name="phone" id="frm-phone" data-nette-rules=\'['
-            . ($this->isNette24 ? '{"op":"optional"},' : '')
-            . '{"op":"Nepada\\\\PhoneNumberInput\\\\Validator::validatePhoneNumber","msg":"Please enter a valid phone number."}'
-            . ']\' value="+420 212 345 678">',
+            '<input type="tel" name="phone" pattern="' . self::PATTERN . '" id="frm-phone" '
+            . 'data-nette-rules=\'[' . ($this->isNette24 ? self::RULE_OPTIONAL : '') . self::RULE_PATTERN . ',' . self::RULE_VALID . ']\' '
+            . 'value="+420 212 345 678">',
             (string) $phoneInput->getControl()
         );
 
         $phoneInput->setValue('+12015550123');
         Assert::same(
-            '<input type="tel" name="phone" id="frm-phone" data-nette-rules=\'['
-            . ($this->isNette24 ? '{"op":"optional"},' : '')
-            . '{"op":"Nepada\\\\PhoneNumberInput\\\\Validator::validatePhoneNumber","msg":"Please enter a valid phone number."}'
-            . ']\' value="+1 201-555-0123">',
+            '<input type="tel" name="phone" pattern="' . self::PATTERN . '" id="frm-phone" '
+            . 'data-nette-rules=\'[' . ($this->isNette24 ? self::RULE_OPTIONAL : '') . self::RULE_PATTERN . ',' . self::RULE_VALID . ']\' '
+            . 'value="+1 201-555-0123">',
             (string) $phoneInput->getControl()
         );
     }
@@ -164,10 +166,8 @@ class PhoneNumberInputTest extends TestCase
         Assert::null($phoneInput->getValue());
         Assert::same(null, $phoneInput->getError());
         Assert::same(
-            '<input type="tel" name="phone" id="frm-phone" data-nette-rules=\'['
-            . ($this->isNette24 ? '{"op":"optional"},' : '')
-            . '{"op":"Nepada\\\\PhoneNumberInput\\\\Validator::validatePhoneNumber","msg":"Please enter a valid phone number."}'
-            . ']\'>',
+            '<input type="tel" name="phone" pattern="' . self::PATTERN . '" id="frm-phone" '
+            . 'data-nette-rules=\'[' . ($this->isNette24 ? self::RULE_OPTIONAL : '') . self::RULE_PATTERN . ',' . self::RULE_VALID . ']\'>',
             (string) $phoneInput->getControl()
         );
     }
@@ -187,10 +187,9 @@ class PhoneNumberInputTest extends TestCase
         Assert::null($phoneInput->getValue());
         Assert::same(null, $phoneInput->getError());
         Assert::same(
-            '<input type="tel" name="phone" id="frm-phone" data-nette-rules=\'['
-            . ($this->isNette24 ? '{"op":"optional"},' : '')
-            . '{"op":"Nepada\\\\PhoneNumberInput\\\\Validator::validatePhoneNumber","msg":"Please enter a valid phone number."}'
-            . ']\' data-nette-empty-value="+420" value="+420">',
+            '<input type="tel" name="phone" pattern="' . self::PATTERN . '" id="frm-phone" '
+            . 'data-nette-rules=\'[' . ($this->isNette24 ? self::RULE_OPTIONAL : '') . self::RULE_PATTERN . ',' . self::RULE_VALID . ']\' '
+            . 'data-nette-empty-value="+420" value="+420">',
             (string) $phoneInput->getControl()
         );
     }
@@ -210,10 +209,9 @@ class PhoneNumberInputTest extends TestCase
         Assert::same('+420212345678', (string) $phoneInput->getValue());
         Assert::same(null, $phoneInput->getError());
         Assert::same(
-            '<input type="tel" name="phone" id="frm-phone" data-nette-rules=\'['
-            . ($this->isNette24 ? '{"op":"optional"},' : '')
-            . '{"op":"Nepada\\\\PhoneNumberInput\\\\Validator::validatePhoneNumber","msg":"Please enter a valid phone number."}'
-            . ']\' value="+420 212 34 56 78">',
+            '<input type="tel" name="phone" pattern="' . self::PATTERN . '" id="frm-phone" '
+            . 'data-nette-rules=\'[' . ($this->isNette24 ? self::RULE_OPTIONAL : '') . self::RULE_PATTERN . ',' . self::RULE_VALID . ']\' '
+            . 'value="+420 212 34 56 78">',
             (string) $phoneInput->getControl()
         );
     }
@@ -233,9 +231,9 @@ class PhoneNumberInputTest extends TestCase
         Assert::null($phoneInput->getValue());
         Assert::same('Please enter a valid phone number.', $phoneInput->getError());
         Assert::same(
-            '<input type="tel" name="phone" id="frm-phone" required data-nette-rules=\''
-            . '[{"op":":filled","msg":"true"},{"op":"Nepada\\\\PhoneNumberInput\\\\Validator::validatePhoneNumber","msg":"Please enter a valid phone number."}]'
-            . '\' value="123">',
+            '<input type="tel" name="phone" pattern="' . self::PATTERN . '" id="frm-phone" required '
+            . 'data-nette-rules=\'[' . self::RULE_REQUIRED . self::RULE_PATTERN . ',' . self::RULE_VALID . ']\' '
+            . 'value="123">',
             (string) $phoneInput->getControl()
         );
     }


### PR DESCRIPTION
Alphabetic numbers are confusing as hell. The input should be limited to only numeric, whitespace and some basic punctation characters.